### PR TITLE
Fix challenge seeded tasks not appearing as todos on Today screen

### DIFF
--- a/rhythm/src/stores/useChallengeStore.ts
+++ b/rhythm/src/stores/useChallengeStore.ts
@@ -191,7 +191,7 @@ export const useChallengeStore = create<ChallengeState>()(
             prevTaskId = taskId;
           }
 
-          taskStore.generateDailyInstances(new Date());
+          seededTaskIds.forEach(taskId => taskStore.scheduleForToday(taskId));
         }
 
         const challenge: ActiveChallenge = {


### PR DESCRIPTION
generateDailyInstances skips tier:'todo' tasks by design, so seeded
challenge tasks never got instances created. Replace the call with
scheduleForToday for each seeded task, which creates pending instances
directly without the tier filter.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DLcjJukpkyQAjKPfogSSvg